### PR TITLE
Added tests for title_display and title_full_display

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,17 +14,31 @@ Bundler/OrderedGems:
 
 # because we have code that is clearer this way
 Metrics/AbcSize:
-  Max: 16
+  Exclude:
+    - 'lib/sparql_to_sw_solr/instance_title_fields.rb'
 
 Metrics/BlockLength:
   Exclude:
     - 'spec/**'
+
+# because some of these methods will need to be a bit complex to deal with punctuation
+Metrics/CyclomaticComplexity:
+  Max: 10
 
 # because this isn't 1970
 Metrics/LineLength:
   Max: 120
   Exclude:
     - 'spec/instance_solr_doc_spec.rb'
+
+# because some of these methods will need to be long
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/sparql_to_sw_solr/instance_title_fields.rb'
+
+# because some of these methods will need to be a bit complex to deal with punctuation
+Metrics/PerceivedComplexity:
+  Max: 10
 
 # because the complexity of this app and its classes shouldn't require this with good naming
 Style/Documentation:
@@ -42,14 +56,13 @@ Style/EmptyLinesAroundClassBody:
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
 
-# because some of these methods will need to be long
-Style/MethodLength:
-  Exclude:
-    - 'lib/sparql_to_sw_solr/instance_title_fields.rb'
-
 # because it doesn't make it more readable
 Style/RegexpLiteral:
   Enabled: false
+
+Style/SpaceInsideStringInterpolation:
+  Exclude:
+    - 'lib/sparql_to_sw_solr/instance_title_fields.rb'
 
 # because it's silly to care
 Style/StringLiterals:

--- a/lib/sparql_to_sw_solr/instance_title_fields.rb
+++ b/lib/sparql_to_sw_solr/instance_title_fields.rb
@@ -13,9 +13,13 @@ module SparqlToSwSolr
         doc[:title_245a_display] = primary_main_title.strip.gsub(/[\\,:;\/ ]+$/, '') if primary_main_title
         primary_subtitle = values_from_solutions(primary_solutions, 'subtitle').first
         # TODO: what should separator be? what if main title ends with '=' ?
-        doc[:title_display] = "#{primary_main_title}, #{primary_subtitle}"
+        doc[:title_display] = "#{primary_main_title.strip.gsub(/[\\,:;\/ ]+$/, '') if primary_main_title}" \
+                              "#{primary_subtitle.present? && primary_main_title.present? ? ' : ' : nil}" \
+                              "#{primary_subtitle.strip.gsub(/[\\,:;\/ ]+$/, '') if primary_subtitle}"
         resp_statement = values_from_solutions(primary_solutions, 'responsibilityStatement').first
-        doc[:title_full_display] = "#{doc[:title_display]} / #{resp_statement}"
+        doc[:title_full_display] = "#{doc[:title_display]}" \
+                                   "#{doc[:title_display].present? && resp_statement.present? ? ' / ' : nil}" \
+                                   "#{resp_statement.gsub(/[\\,:;\/ ]+$/, '') if resp_statement}"
         doc
       end
 


### PR DESCRIPTION
Modified add_doc_title_fields method to better match metadata's spec, specifically, if there is no subtitle to go with the mainTitle, it must also not include the colon separator. Similarly, with responsibilityStatement, it must not include the forward-slash if there is no resp_statement found. Connected to #26 