### PR TITLE
InstanceSolrDoc#concatenate_values returns String

### DIFF
--- a/lib/sparql_to_sw_solr/instance_solr_doc.rb
+++ b/lib/sparql_to_sw_solr/instance_solr_doc.rb
@@ -79,10 +79,7 @@ module SparqlToSwSolr
     end
 
     def concatenate_values(val1, separator, val2)
-      result = "#{val1}" \
-      "#{present?(val1) && present?(val2) ? separator : nil}" \
-      "#{val2}"
-      result unless result.empty?
+      [val1, val2].map(&:to_s).map(&:strip).reject(&:empty?).join(separator)
     end
 
     def sparql

--- a/spec/instance_pub_fields_spec.rb
+++ b/spec/instance_pub_fields_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::InstancePubFields do
       exp_val = "#{edition_val} - #{pub_info}. #{manu_place} : #{manu_agent}, #{manu_date}"
       expect(isd.send(:imprint_display)).to eq exp_val
     end
-    it 'is nil if there is no value for edition, publication or manufacture' do
-      expect(isd.send(:imprint_display)).to be nil
+    it 'is empty if there is no value for edition, publication or manufacture' do
+      expect(isd.send(:imprint_display)).to be_empty
     end
     it 'publication + manufacture if no edition info' do
       pub_solns = RDF::Query::Solutions.new

--- a/spec/instance_solr_doc_spec.rb
+++ b/spec/instance_solr_doc_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc do
     it 'is string val1 + separator + val2 when val1 and val2 both exist' do
       expect(isd.send(:concatenate_values, val1, sep, val2)).to eq 'toe floof rocks'
     end
-    it 'nil if val1 and val2 both nil' do
-      expect(isd.send(:concatenate_values, nil, sep, nil)).to eq nil
+    it 'empty if val1 and val2 both nil' do
+      expect(isd.send(:concatenate_values, nil, sep, nil)).to be_empty
     end
     it 'outputs only val1 (no sep) when nil val2' do
       expect(isd.send(:concatenate_values, val1, sep, nil)).to eq val1

--- a/spec/instance_title_fields_spec.rb
+++ b/spec/instance_title_fields_spec.rb
@@ -142,9 +142,9 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::InstanceTitleFields do
         expect(sparql_conn).to receive(:query).and_return(solutions)
         expect(doc_hash[:title_display]).to eq 'bar'
       end
-      it 'nil if no mainTitle or subtitle value' do
+      it 'empty if no mainTitle or subtitle value' do
         expect(sparql_conn).to receive(:query).and_return(solutions)
-        expect(doc_hash[:title_display]).to eq nil
+        expect(doc_hash[:title_display]).to be_empty
       end
       it 'removes trailing punctuation' do
         ['\\', ',', ':', ';', '/'].each do |punct|
@@ -188,9 +188,9 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::InstanceTitleFields do
           title_display = doc_hash[:title_display]
           expect(doc_hash[:title_full_display]).to eq(title_display)
         end
-        it 'nil if no title_display value' do
+        it 'is empty if no title_display value' do
           expect(sparql_conn).to receive(:query).and_return(solutions)
-          expect(doc_hash[:title_full_display]).to eq nil
+          expect(doc_hash[:title_full_display]).to be_empty
         end
       end
 
@@ -241,16 +241,16 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::InstanceTitleFields do
       end
 
       context 'no title_display' do
-        it 'nil if no title_display or resp statement' do
+        it 'is empty if no title_display or resp statement' do
           expect(sparql_conn).to receive(:query).and_return(solutions)
-          expect(doc_hash[:title_display]).to eq nil
-          expect(doc_hash[:title_full_display]).to eq nil
+          expect(doc_hash[:title_display]).to be_empty
+          expect(doc_hash[:title_full_display]).to be_empty
         end
         it 'responsibility statement without prefix separator if no title_display value' do
           expect(sparql_conn).to receive(:query).and_return(solutions)
           solutions << RDF::Query::Solution.new(p: 'responsibilityStatement', o: 'roo')
           allow(isd).to receive(:sparql).and_return(sparql_conn)
-          expect(doc_hash[:title_display]).to eq nil
+          expect(doc_hash[:title_display]).to be_empty
           expect(doc_hash[:title_full_display]).to eq 'roo'
         end
       end


### PR DESCRIPTION
Exploration of returning Strings (empty string, instead of nil) for InstanceSolrDoc#concatenate_values

See https://github.com/sul-dlss/sparql_to_sw_solr/pull/54#discussion_r111015337