### PR TITLE
Add physical field to solr doc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Metrics/MethodLength:
   Max: 12
   Exclude:
     - 'lib/sparql_to_sw_solr/instance_pub_fields.rb'
+    - 'lib/sparql_to_sw_solr/physical_field.rb'
 
 # because the simplicity of this app and its classes shouldn't require this with good naming
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,6 @@ Metrics/MethodLength:
   Max: 12
   Exclude:
     - 'lib/sparql_to_sw_solr/instance_pub_fields.rb'
-    - 'lib/sparql_to_sw_solr/physical_field.rb'
 
 # because the simplicity of this app and its classes shouldn't require this with good naming
 Style/Documentation:

--- a/lib/sparql_to_sw_solr/instance_solr_doc.rb
+++ b/lib/sparql_to_sw_solr/instance_solr_doc.rb
@@ -4,6 +4,7 @@ require_relative 'instance_pub_fields'
 require_relative 'instance_title_fields'
 require_relative 'language_field'
 require_relative 'topic_fields'
+require_relative 'physical_field'
 
 module SparqlToSwSolr
   class InstanceSolrDoc
@@ -12,6 +13,7 @@ module SparqlToSwSolr
     include InstanceTitleFields
     include LanguageField
     include TopicFields
+    include PhysicalField
 
     # TODO: get these from settings.yml
     SPARQL_URL = 'http://localhost:8080/blazegraph/namespace/ld4p/sparql'.freeze
@@ -44,6 +46,7 @@ module SparqlToSwSolr
         return if CKEY_BLACKLIST.include?(@ckey)
         doc = init_doc
         doc[:language] = language_values
+        doc[:physical] = physical_values
         add_author_fields(doc)
         add_publication_fields(doc)
         add_title_fields(doc)

--- a/lib/sparql_to_sw_solr/physical_field.rb
+++ b/lib/sparql_to_sw_solr/physical_field.rb
@@ -4,19 +4,21 @@ module SparqlToSwSolr
 
       private
 
+      # Using the physical_solutions query below, extentLabel_1 and instanceDimensions_3
+      # are always each the same value for every query solution; the note_case method
+      # will collect each note information for the physical note types.
       def physical_values
-        physical_solutions.each_solution do |soln|
-          next unless soln.bindings.keys.include?(:noteType)
-          @note_type = soln.noteType.to_s
-          @physical1 = soln.extentLabel_1.to_s
-          @physical3 = soln.instanceDimensions_3.to_s
-          note_case(soln)
-        end
-        physical_details
+        return if physical_solutions.empty?
+        soln = physical_solutions.first
+        @physical1 = soln.extentLabel_1.to_s
+        @physical3 = soln.instanceDimensions_3.to_s
+        physical_solutions.each_solution { |s| note_case(s) }
+        physical_details # concatenate all the physical information
       end
 
       def note_case(soln)
-        case @note_type
+        return unless soln.bindings.keys.include?(:noteType)
+        case soln.noteType.to_s
         when 'Physical details'
           @physical2 = soln.noteLabel.to_s
         when 'Accompanying materials'
@@ -30,21 +32,24 @@ module SparqlToSwSolr
         concatenate_values(extent_details_dimensions, ' + ', @physical4)
       end
 
+      # extentLabel_1 and instanceDimensions_3 are required fields according to the MARC specification
       def physical_solutions
-        query = "#{BF_NS_DECL}
-        SELECT distinct ?extentLabel_1 ?noteType ?noteLabel ?instanceDimensions_3
-        WHERE {
-          <#{instance_uri}> bf:extent ?e .
-          ?e rdfs:label ?extentLabel_1 .
-          <#{instance_uri}> bf:dimensions ?instanceDimensions_3 .
-          OPTIONAL {
-            <#{instance_uri}> bf:note ?note .
-            ?note bf:noteType ?noteType;
-            	  rdfs:label ?noteLabel .
+        @physical_solutions ||= begin
+          query = "#{BF_NS_DECL}
+          SELECT distinct ?extentLabel_1 ?noteType ?noteLabel ?instanceDimensions_3
+          WHERE {
+            <#{instance_uri}> bf:extent ?e .
+            ?e rdfs:label ?extentLabel_1 .
+            <#{instance_uri}> bf:dimensions ?instanceDimensions_3 .
+            OPTIONAL {
+              <#{instance_uri}> bf:note ?note .
+              ?note bf:noteType ?noteType;
+              	  rdfs:label ?noteLabel .
+            }
           }
-        }
-        ".freeze
-        sparql.query(query)
+          ".freeze
+          sparql.query(query)
+        end
       end
     end
   end

--- a/lib/sparql_to_sw_solr/physical_field.rb
+++ b/lib/sparql_to_sw_solr/physical_field.rb
@@ -1,0 +1,51 @@
+module SparqlToSwSolr
+  class InstanceSolrDoc
+    module PhysicalField
+
+      private
+
+      def physical_values
+        physical_solutions.each_solution do |soln|
+          next unless soln.bindings.keys.include?(:noteType)
+          @note_type = soln.noteType.to_s
+          @physical1 = soln.extentLabel_1.to_s
+          @physical3 = soln.instanceDimensions_3.to_s
+          note_case(soln)
+        end
+        physical_details
+      end
+
+      def note_case(soln)
+        case @note_type
+        when 'Physical details'
+          @physical2 = soln.noteLabel.to_s
+        when 'Accompanying materials'
+          @physical4 = soln.noteLabel.to_s
+        end
+      end
+
+      def physical_details
+        extent_details = concatenate_values(@physical1, ' : ', @physical2)
+        extent_details_dimensions = concatenate_values(extent_details, ' ; ', @physical3)
+        concatenate_values(extent_details_dimensions, ' + ', @physical4)
+      end
+
+      def physical_solutions
+        query = "#{BF_NS_DECL}
+        SELECT distinct ?extentLabel_1 ?noteType ?noteLabel ?instanceDimensions_3
+        WHERE {
+          <#{instance_uri}> bf:extent ?e .
+          ?e rdfs:label ?extentLabel_1 .
+          <#{instance_uri}> bf:dimensions ?instanceDimensions_3 .
+          OPTIONAL {
+            <#{instance_uri}> bf:note ?note .
+            ?note bf:noteType ?noteType;
+            	  rdfs:label ?noteLabel .
+          }
+        }
+        ".freeze
+        sparql.query(query)
+      end
+    end
+  end
+end

--- a/lib/sparql_to_sw_solr/physical_field.rb
+++ b/lib/sparql_to_sw_solr/physical_field.rb
@@ -32,23 +32,23 @@ module SparqlToSwSolr
         concatenate_values(extent_details_dimensions, ' + ', @physical4)
       end
 
-      # extentLabel_1 and instanceDimensions_3 are required fields according to the MARC specification
       def physical_solutions
-        @physical_solutions ||= begin
-          query = "#{BF_NS_DECL}
+        @physical_solutions ||= sparql.query(physical_query)
+      end
+
+      # extentLabel_1 and instanceDimensions_3 are required fields according to the MARC specification
+      def physical_query
+        @physical_query ||= begin
+          "#{BF_NS_DECL}
           SELECT distinct ?extentLabel_1 ?noteType ?noteLabel ?instanceDimensions_3
           WHERE {
             <#{instance_uri}> bf:extent ?e .
             ?e rdfs:label ?extentLabel_1 .
             <#{instance_uri}> bf:dimensions ?instanceDimensions_3 .
-            OPTIONAL {
-              <#{instance_uri}> bf:note ?note .
-              ?note bf:noteType ?noteType;
-              	  rdfs:label ?noteLabel .
-            }
-          }
-          ".freeze
-          sparql.query(query)
+            OPTIONAL { <#{instance_uri}> bf:note ?note .
+                       ?note bf:noteType ?noteType;
+              	             rdfs:label ?noteLabel . }
+          }".freeze
         end
       end
     end

--- a/spec/instance_solr_doc_spec.rb
+++ b/spec/instance_solr_doc_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc do
         expect(doc_hash).to include(language: lang_value)
       end
       it 'physical field' do
-        expect(isd).to receive(:physical_values)
+        expect(isd).to receive(:physical_values).and_return('')
         isd.solr_doc_hash
       end
     end

--- a/spec/instance_solr_doc_spec.rb
+++ b/spec/instance_solr_doc_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc do
         expect(isd).to receive(:language_values).and_return(lang_value)
         expect(doc_hash).to include(language: lang_value)
       end
+      it 'physical field' do
+        expect(isd).to receive(:physical_values)
+        isd.solr_doc_hash
+      end
     end
   end
 

--- a/spec/physical_field_spec.rb
+++ b/spec/physical_field_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
+
+  let(:instance_uri) { 'http://ld4p-test.stanford.edu/1234567890#Instance' }
+  let(:isd) { SparqlToSwSolr::InstanceSolrDoc.new(instance_uri) }
+  let(:sparql_conn) { double('sparql client') }
+  let(:solutions) { RDF::Query::Solutions.new }
+
+  before(:each) do
+    allow(isd).to receive(:sparql).and_return(sparql_conn)
+    allow(sparql_conn).to receive(:query).and_return(solutions)
+  end
+
+  context '#physical_values' do
+    it 'is a String consisting of the results from a query solution' do
+      solutions << RDF::Query::Solution.new(noteType: 'Physical details',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      physical_values = isd.send(:physical_values)
+      expect(physical_values).to eq '15 p. : ill. ; 5 x 5 in.'
+    end
+    it 'includes noteLabel for "accompanying material" when it exists as a solutions with a different noteType' do
+      solutions << RDF::Query::Solution.new(noteType: 'Physical details',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      solutions << RDF::Query::Solution.new(noteType: 'Accompanying materials',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'CD',
+                                            instanceDimensions_3: '5 x 5 in.')
+      physical_values = isd.send(:physical_values)
+      expect(physical_values).to eq '15 p. : ill. ; 5 x 5 in. + CD'
+    end
+    it 'Concatenates the physical_details correctly if there is no extentLabel_1' do
+      solutions << RDF::Query::Solution.new(noteType: 'Physical details',
+                                            extentLabel_1: nil,
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      physical_values = isd.send(:physical_values)
+      expect(physical_values).to eq 'ill. ; 5 x 5 in.'
+    end
+    it 'Concatenates the physical_details correctly if there is no instanceDimensions_3' do
+      solutions << RDF::Query::Solution.new(noteType: 'Physical details',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: nil)
+      physical_values = isd.send(:physical_values)
+      expect(physical_values).to eq '15 p. : ill.'
+    end
+    it 'Leaves out the noteLabel if neither noteType "Accompanying material" or "Physical details" exist' do
+      solutions << RDF::Query::Solution.new(noteType: 'foo',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      physical_values = isd.send(:physical_values)
+      expect(physical_values).to eq '15 p. ; 5 x 5 in.'
+    end
+    it 'Returns nothing if there is no noteType' do
+      solutions << RDF::Query::Solution.new(extentLabel_1: '15 p.',
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      physical_values = isd.send(:physical_values)
+      expect(physical_values).to eq nil
+    end
+  end
+end

--- a/spec/physical_field_spec.rb
+++ b/spec/physical_field_spec.rb
@@ -31,19 +31,21 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
       physical_values = isd.send(:physical_values)
       expect(physical_values).to eq '15 p. : ill. ; 5 x 5 in. + CD'
     end
+    # extentLabel_1 is a required field according to the MARC specification, but check incase it's empty
     it 'Concatenates the physical_details correctly if there is no extentLabel_1' do
       solutions << RDF::Query::Solution.new(noteType: 'Physical details',
-                                            extentLabel_1: nil,
+                                            extentLabel_1: '',
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '5 x 5 in.')
       physical_values = isd.send(:physical_values)
       expect(physical_values).to eq 'ill. ; 5 x 5 in.'
     end
+    # instanceDimensions_3 is a required field according to the MARC specification, but check incase it's empty
     it 'Concatenates the physical_details correctly if there is no instanceDimensions_3' do
       solutions << RDF::Query::Solution.new(noteType: 'Physical details',
                                             extentLabel_1: '15 p.',
                                             noteLabel: 'ill.',
-                                            instanceDimensions_3: nil)
+                                            instanceDimensions_3: '')
       physical_values = isd.send(:physical_values)
       expect(physical_values).to eq '15 p. : ill.'
     end
@@ -60,7 +62,8 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '5 x 5 in.')
       physical_values = isd.send(:physical_values)
-      expect(physical_values).to eq nil
+      # expect(physical_values).to eq nil
+      expect(physical_values).to eq '15 p. ; 5 x 5 in.'
     end
   end
 end

--- a/spec/physical_field_spec.rb
+++ b/spec/physical_field_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
                                             extentLabel_1: '15 p.',
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '5 x 5 in.')
-      physical_values = isd.send(:physical_values)
-      expect(physical_values).to eq '15 p. : ill. ; 5 x 5 in.'
+      expect(isd.send(:physical_values)).to eq '15 p. : ill. ; 5 x 5 in.'
     end
     it 'includes noteLabel for "accompanying material" when it exists as a solutions with a different noteType' do
       solutions << RDF::Query::Solution.new(noteType: 'Physical details',
@@ -28,8 +27,18 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
                                             extentLabel_1: '15 p.',
                                             noteLabel: 'CD',
                                             instanceDimensions_3: '5 x 5 in.')
-      physical_values = isd.send(:physical_values)
-      expect(physical_values).to eq '15 p. : ill. ; 5 x 5 in. + CD'
+      expect(isd.send(:physical_values)).to eq '15 p. : ill. ; 5 x 5 in. + CD'
+    end
+    it 'ignores other noteTypes if they exist as a solution' do
+      solutions << RDF::Query::Solution.new(noteType: 'Physical details',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'ill.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      solutions << RDF::Query::Solution.new(noteType: 'bibliography',
+                                            extentLabel_1: '15 p.',
+                                            noteLabel: 'Includes bibliographical references.',
+                                            instanceDimensions_3: '5 x 5 in.')
+      expect(isd.send(:physical_values)).to eq '15 p. : ill. ; 5 x 5 in.'
     end
     # extentLabel_1 is a required field according to the MARC specification, but check incase it's empty
     it 'Concatenates the physical_details correctly if there is no extentLabel_1' do
@@ -37,8 +46,7 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
                                             extentLabel_1: '',
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '5 x 5 in.')
-      physical_values = isd.send(:physical_values)
-      expect(physical_values).to eq 'ill. ; 5 x 5 in.'
+      expect(isd.send(:physical_values)).to eq 'ill. ; 5 x 5 in.'
     end
     # instanceDimensions_3 is a required field according to the MARC specification, but check incase it's empty
     it 'Concatenates the physical_details correctly if there is no instanceDimensions_3' do
@@ -46,24 +54,20 @@ RSpec.describe SparqlToSwSolr::InstanceSolrDoc::PhysicalField do
                                             extentLabel_1: '15 p.',
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '')
-      physical_values = isd.send(:physical_values)
-      expect(physical_values).to eq '15 p. : ill.'
+      expect(isd.send(:physical_values)).to eq '15 p. : ill.'
     end
     it 'Leaves out the noteLabel if neither noteType "Accompanying material" or "Physical details" exist' do
       solutions << RDF::Query::Solution.new(noteType: 'foo',
                                             extentLabel_1: '15 p.',
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '5 x 5 in.')
-      physical_values = isd.send(:physical_values)
-      expect(physical_values).to eq '15 p. ; 5 x 5 in.'
+      expect(isd.send(:physical_values)).to eq '15 p. ; 5 x 5 in.'
     end
     it 'Returns nothing if there is no noteType' do
       solutions << RDF::Query::Solution.new(extentLabel_1: '15 p.',
                                             noteLabel: 'ill.',
                                             instanceDimensions_3: '5 x 5 in.')
-      physical_values = isd.send(:physical_values)
-      # expect(physical_values).to eq nil
-      expect(physical_values).to eq '15 p. ; 5 x 5 in.'
+      expect(isd.send(:physical_values)).to eq '15 p. ; 5 x 5 in.'
     end
   end
 end


### PR DESCRIPTION
Fix #50 

I wasn't sure if I needed to test the methods in `lib/sparql_to_sw_solr/physical_field.rb` other than `physical_values` since that method calls the other ones in the module.